### PR TITLE
Changed "Edit on Github" to "View on Github"

### DIFF
--- a/contributing/index.html
+++ b/contributing/index.html
@@ -242,8 +242,8 @@
     <li>Contributing</li>
     <li class="wy-breadcrumbs-aside">
       
-        <a href="https://github.com/tqdm/tqdm/edit/master/docs/contributing.md"
-          class="icon icon-github"> Edit on GitHub</a>
+        <a href="https://github.com/tqdm/tqdm/"
+          class="icon icon-github"> View on GitHub</a>
       
     </li>
   </ul>

--- a/docs/TMonitor/index.html
+++ b/docs/TMonitor/index.html
@@ -219,8 +219,8 @@
     <li>tqdm.TMonitor</li>
     <li class="wy-breadcrumbs-aside">
       
-        <a href="https://github.com/tqdm/tqdm/edit/master/docs/docs/TMonitor.md"
-          class="icon icon-github"> Edit on GitHub</a>
+        <a href="https://github.com/tqdm/tqdm/"
+          class="icon icon-github"> View on GitHub</a>
       
     </li>
   </ul>

--- a/docs/shortcuts/index.html
+++ b/docs/shortcuts/index.html
@@ -228,8 +228,8 @@
     <li>Shortcuts</li>
     <li class="wy-breadcrumbs-aside">
       
-        <a href="https://github.com/tqdm/tqdm/edit/master/docs/docs/shortcuts.md"
-          class="icon icon-github"> Edit on GitHub</a>
+        <a href="https://github.com/tqdm/tqdm/"
+          class="icon icon-github"> View on GitHub</a>
       
     </li>
   </ul>

--- a/docs/tqdm/index.html
+++ b/docs/tqdm/index.html
@@ -279,8 +279,8 @@
     <li>tqdm.tqdm</li>
     <li class="wy-breadcrumbs-aside">
       
-        <a href="https://github.com/tqdm/tqdm/edit/master/docs/docs/tqdm.md"
-          class="icon icon-github"> Edit on GitHub</a>
+        <a href="https://github.com/tqdm/tqdm/"
+          class="icon icon-github"> View on GitHub</a>
       
     </li>
   </ul>

--- a/docs/tqdm_gui/index.html
+++ b/docs/tqdm_gui/index.html
@@ -219,8 +219,8 @@
     <li>tqdm.tqdm_gui</li>
     <li class="wy-breadcrumbs-aside">
       
-        <a href="https://github.com/tqdm/tqdm/edit/master/docs/docs/tqdm_gui.md"
-          class="icon icon-github"> Edit on GitHub</a>
+        <a href="https://github.com/tqdm/tqdm/"
+          class="icon icon-github"> View on GitHub</a>
       
     </li>
   </ul>

--- a/docs/tqdm_notebook/index.html
+++ b/docs/tqdm_notebook/index.html
@@ -219,8 +219,8 @@
     <li>tqdm.tqdm_notebook</li>
     <li class="wy-breadcrumbs-aside">
       
-        <a href="https://github.com/tqdm/tqdm/edit/master/docs/docs/tqdm_notebook.md"
-          class="icon icon-github"> Edit on GitHub</a>
+        <a href="https://github.com/tqdm/tqdm/"
+          class="icon icon-github"> View on GitHub</a>
       
     </li>
   </ul>

--- a/docs/warnings/index.html
+++ b/docs/warnings/index.html
@@ -237,8 +237,8 @@
     <li>Warnings and Exceptions</li>
     <li class="wy-breadcrumbs-aside">
       
-        <a href="https://github.com/tqdm/tqdm/edit/master/docs/docs/warnings.md"
-          class="icon icon-github"> Edit on GitHub</a>
+        <a href="https://github.com/tqdm/tqdm/"
+          class="icon icon-github"> View on GitHub</a>
       
     </li>
   </ul>

--- a/index.html
+++ b/index.html
@@ -215,8 +215,8 @@
     <li>Home</li>
     <li class="wy-breadcrumbs-aside">
       
-        <a href="https://github.com/tqdm/tqdm/edit/master/docs/index.md"
-          class="icon icon-github"> Edit on GitHub</a>
+        <a href="https://github.com/tqdm/tqdm/"
+          class="icon icon-github"> View on GitHub</a>
       
     </li>
   </ul>

--- a/licence/index.html
+++ b/licence/index.html
@@ -218,8 +218,8 @@
     <li>Licence</li>
     <li class="wy-breadcrumbs-aside">
       
-        <a href="https://github.com/tqdm/tqdm/edit/master/docs/licence.md"
-          class="icon icon-github"> Edit on GitHub</a>
+        <a href="https://github.com/tqdm/tqdm/"
+          class="icon icon-github"> View on GitHub</a>
       
     </li>
   </ul>

--- a/ports/index.html
+++ b/ports/index.html
@@ -212,8 +212,8 @@
     <li>Ports to Other Languages</li>
     <li class="wy-breadcrumbs-aside">
       
-        <a href="https://github.com/tqdm/tqdm/edit/master/docs/ports.md"
-          class="icon icon-github"> Edit on GitHub</a>
+        <a href="https://github.com/tqdm/tqdm/"
+          class="icon icon-github"> View on GitHub</a>
       
     </li>
   </ul>

--- a/releases/index.html
+++ b/releases/index.html
@@ -329,8 +329,8 @@
     <li>Release History</li>
     <li class="wy-breadcrumbs-aside">
       
-        <a href="https://github.com/tqdm/tqdm/edit/master/docs/releases.md"
-          class="icon icon-github"> Edit on GitHub</a>
+        <a href="https://github.com/tqdm/tqdm/"
+          class="icon icon-github"> View on GitHub</a>
       
     </li>
   </ul>


### PR DESCRIPTION
This closes #1

Note that this PR changes all hyperlinks of "Edit on Github" to point to the main Github repository.